### PR TITLE
Fix: handle space in things url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ async function openThingsURL(url: string): Promise<void> {
   }
 }
 
+// URLSearchParams encodes spaces as '+', but Things URL scheme expects '%20'
+function buildThingsQueryString(params: URLSearchParams): string {
+  return params.toString().replace(/\+/g, "%20");
+}
+
 server.tool(
   "add-todo",
   {
@@ -124,7 +129,7 @@ server.tool(
     if (params["completion-date"])
       urlParams.set("completion-date", params["completion-date"]);
 
-    const url = `things:///add?${urlParams.toString()}`;
+    const url = `things:///add?${buildThingsQueryString(urlParams)}`;
     await openThingsURL(url);
 
     const todoName = params.titles
@@ -212,7 +217,7 @@ server.tool(
     if (params["completion-date"])
       urlParams.set("completion-date", params["completion-date"]);
 
-    const url = `things:///add-project?${urlParams.toString()}`;
+    const url = `things:///add-project?${buildThingsQueryString(urlParams)}`;
     await openThingsURL(url);
 
     return {
@@ -337,7 +342,7 @@ server.tool(
     if (params["completion-date"])
       urlParams.set("completion-date", params["completion-date"]);
 
-    const url = `things:///update?${urlParams.toString()}`;
+    const url = `things:///update?${buildThingsQueryString(urlParams)}`;
     await openThingsURL(url);
 
     return {
@@ -434,7 +439,7 @@ server.tool(
     if (params["completion-date"])
       urlParams.set("completion-date", params["completion-date"]);
 
-    const url = `things:///update-project?${urlParams.toString()}`;
+    const url = `things:///update-project?${buildThingsQueryString(urlParams)}`;
     await openThingsURL(url);
 
     return {
@@ -476,7 +481,7 @@ server.tool(
       urlParams.set("filter", params.filter.join(","));
     }
 
-    const url = `things:///show?${urlParams.toString()}`;
+    const url = `things:///show?${buildThingsQueryString(urlParams)}`;
     await openThingsURL(url);
 
     const target = params.id || params.query || "Things";
@@ -500,7 +505,7 @@ server.tool(
     const urlParams = new URLSearchParams();
     if (params.query) urlParams.set("query", params.query);
 
-    const url = `things:///search?${urlParams.toString()}`;
+    const url = `things:///search?${buildThingsQueryString(urlParams)}`;
     await openThingsURL(url);
 
     return {
@@ -564,7 +569,7 @@ server.tool(
       urlParams.set("reveal", params.reveal.toString());
     }
 
-    const url = `things:///json?${urlParams.toString()}`;
+    const url = `things:///json?${buildThingsQueryString(urlParams)}`;
     await openThingsURL(url);
 
     return {


### PR DESCRIPTION
We have `+` sign instead of space when trying to create tasks from cursor

Before

<img width="556" height="110" alt="image" src="https://github.com/user-attachments/assets/e6b01032-589c-40a0-bbf2-9077c25cd759" />

After

<img width="486" height="82" alt="image" src="https://github.com/user-attachments/assets/6cb96d94-87f0-47b0-b67f-1241f79e06f4" />
